### PR TITLE
doc: add Jean-Christophe to list of TC members (#4551)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 # - Either Dominik (oncilla) or Lukas (lukedirtwalker) should be involved for
 #   changes that could impact the compatibility between this implementation and
 #   their proprietary system.
-# - Matthias (matzf) would like to be involved for changes to the router
+# - Jean-Christophe (jiceatscion) would like to be involved for changes to the router
 antlr/** @oncilla @lukedirtwalker
 control/trust/** @oncilla
 gateway/dataplane/encoder.go @oncilla @lukedirtwalker
@@ -21,6 +21,6 @@ pkg/slayers/** @scionproto/scion-core-team
 pkg/snet/** @scionproto/scion-core-team
 private/trust/** @oncilla
 proto/** @oncilla @lukedirtwalker
-router/dataplane.go @matzf
+router/dataplane.go @jiceatscion
 scion-pki/** @oncilla
 tools/braccept/cases/** @scionproto/scion-core-team

--- a/doc/dev/contribute.rst
+++ b/doc/dev/contribute.rst
@@ -93,11 +93,11 @@ implementation projects.
 
 The current members of the TC Implementation are:
 
+* Jean-Christophe Hugly (|span-github| `@jiceatscion <https://github.com/jiceatscion>`_, |span-slack| @Jean-Christophe Hugly)
 * Dominik Roos (|span-github| `@oncilla <https://github.com/oncilla>`_, |span-slack| @roosd)
 * François Wirz (|span-github| `@FR4NK-W <https://github.com/FR4NK-W>`_, |span-slack| @frank)
 * Lukas Vogel (|span-github| `@lukedirtwalker <https://github.com/lukedirtwalker>`_, |span-slack| @luke)
 * Marc Frei (|span-github| `@marcfrei <https://github.com/marcfrei>`_, |span-slack| @marcfrei)
-* Matthias Frei (|span-github| `@matzf <https://github.com/matzf>`_, |span-slack| @matzf)
 
 
 .. rubric:: Responsibilities and Tasks

--- a/doc/dev/testing/buildkite.rst
+++ b/doc/dev/testing/buildkite.rst
@@ -89,7 +89,7 @@ Cluster configuration
 
    The agent cluster is operated by the SCION Association, in the AWS account ``scion-association``.
 
-   Primary contacts `matzf <https://github.com/matzf>`_, `jiceatscion <https://github.com/jiceatscion>`_,
+   Primary contact `jiceatscion <https://github.com/jiceatscion>`_,
    alt contact `nicorusti <https://github.com/nicorusti>`_.
 
 


### PR DESCRIPTION
JC has been appointed to the TC Implementation by the SCION Association Board on 21.5.2024, replacing matzf.
Remove matzf from CODEOWNERS, and other docs. Add JC as code owner for router/